### PR TITLE
Tweak Esperanto translation

### DIFF
--- a/locale/connected_chests.eo.tr
+++ b/locale/connected_chests.eo.tr
@@ -1,3 +1,3 @@
 # textdomain: connected_chests
 Big Chest=Kestego
-Big Locked Chest=Ŝlosita Kestego
+Big Locked Chest=Ŝlosita kestego


### PR DESCRIPTION
This tweaks item names’ capitalization to match that used in Minetest game’s Esperanto translation, which [recently switched](https://github.com/minetest/minetest_game/pull/3092/commits/30b0a6cff0fdd86c2a2d95b5b392525075ecba6c) to the lowercase style used by French, Polish, etc. ^ ^